### PR TITLE
fix normalization examples

### DIFF
--- a/doc/unf_examples.txt
+++ b/doc/unf_examples.txt
@@ -32,8 +32,8 @@ values with >7 digits of precision:
 (note that the following 2 values produce the same UNF - because of the 
 "ties to even" rounding mode used!)
 
-1.2345675		"+1.234568e+1\n\000"
-1.2345685		"+1.234568e+1\n\000"
+1.2345675		"+1.234568e+\n\000"
+1.2345685		"+1.234568e+\n\000"
 
 "special" values: 
 


### PR DESCRIPTION
There is no exponent in the character string when the exponent is 1.
