### PR TITLE
Revert "no-op to test CI"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-
     <scm>
         <connection>scm:git:git@github.com:IQSS/UNF.git</connection>
         <developerConnection>scm:git:git@github.com:IQSS/UNF.git</developerConnection>


### PR DESCRIPTION
This reverts commit 424b905062582346d6ac9523974106b24a257b66.